### PR TITLE
2 add mcmc lib

### DIFF
--- a/fab/__init__.py
+++ b/fab/__init__.py
@@ -1,1 +1,1 @@
-from fab.types import TargetLogProbFunc, XPoints, MCMCTransitionManager, HaikuDistribution
+from fab.types import LogProbFunc, XPoints, MCMCTransitionManager, HaikuDistribution

--- a/fab/agent/fab_agent.py
+++ b/fab/agent/fab_agent.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 import pathlib
 import matplotlib.pyplot as plt
 
-from fab.types import TargetLogProbFunc, HaikuDistribution
+from fab.types import LogProbFunc, HaikuDistribution
 from fab.sampling_methods.annealed_importance_sampling import AnnealedImportanceSampler
 from fab.utils.logging import Logger, ListLogger, to_numpy
 from fab.utils.numerical_utils import effective_sample_size_from_unnormalised_log_weights
@@ -37,14 +37,14 @@ class AgentFAB:
     """Flow Annealed Importance Sampling Bootstrap Agent"""
     def __init__(self,
                  learnt_distribution: HaikuDistribution,
-                 target_log_prob: TargetLogProbFunc,
+                 target_log_prob: LogProbFunc,
                  n_intermediate_distributions: int = 2,
                  loss_type: str = "alpha_2_div",
                  soften_ais_weights: bool = True,
                  style: str = "vanilla",
                  add_reverse_kl_loss: bool = False,
                  reverse_kl_loss_coeff: float = 0.001,
-                 AIS_kwargs: Dict = {},
+                 AIS_kwargs: Dict = {"transition_operator_type": "hmc_tfp"},
                  seed: int = 0,
                  optimizer: optax.GradientTransformation = optax.adam(1e-4),
                  plotter: Optional[Plotter] = None,

--- a/fab/agent/fab_agent.py
+++ b/fab/agent/fab_agent.py
@@ -61,7 +61,7 @@ class AgentFAB:
         self.evaluator = evaluator
         self.logger = logger
         self.annealed_importance_sampler = AnnealedImportanceSampler(dim=self.learnt_distribution.dim,
-            n_intermediate_distributions=n_intermediate_distributions, **AIS_kwargs)
+                n_intermediate_distributions=n_intermediate_distributions, **AIS_kwargs)
         self.optimizer = optimizer
         self.state = self.init_state(seed)
         self.reverse_kl_loss_coeff = reverse_kl_loss_coeff
@@ -78,8 +78,7 @@ class AgentFAB:
                                                                             dummy_x)
 
         optimizer_state = self.optimizer.init(learnt_distribution_params)
-        transition_operator_state = self.annealed_importance_sampler.\
-            transition_operator_manager.get_init_state()
+        transition_operator_state = self.annealed_importance_sampler.get_init_state()
         state = State(key=key, learnt_distribution_params=learnt_distribution_params,
                       transition_operator_state=transition_operator_state,
                       optimizer_state=optimizer_state)

--- a/fab/agent/fab_agent_test.py
+++ b/fab/agent/fab_agent_test.py
@@ -75,7 +75,7 @@ class Test_AgentFAB(absltest.TestCase):
     eval_batch_size = batch_size
 
     # AIS_kwargs = {"additional_transition_operator_kwargs": {"step_tuning_method": "p_accept"}}
-    AIS_kwargs = {"transition_operator_type": "hmc_tfp"}
+    AIS_kwargs = {"transition_operator_type": "hmc_tfp"}  #  "hmc_tfp", "nuts_tfp"
 
     if max_grad_norm is None:
         optimizer = optax.chain(optax.zero_nans(), optax.adam(lr))
@@ -93,7 +93,7 @@ class Test_AgentFAB(absltest.TestCase):
                          plotter=plotter,
                          style=style,
                          add_reverse_kl_loss=use_reparam_loss,
-                         soften_ais_weights=soften_ais_weights
+                         soften_ais_weights=soften_ais_weights,
                          )
 
     def test_fab_agent(self):

--- a/fab/sampling_methods/base.py
+++ b/fab/sampling_methods/base.py
@@ -1,0 +1,30 @@
+import abc
+from typing import Dict, Tuple
+
+import chex
+
+X = chex.Array
+LogWeights = chex.Array
+TransitionOperatorState = chex.ArrayTree
+Info = Dict[str, chex.Array]
+
+class AnnealedImportanceSamplerBase(abc.ABC):
+    @abc.abstractmethod
+    def __init__(self,
+                 dim: int,
+                 n_intermediate_distributions: int,
+                 *args,
+                 **kwargs
+                 ):
+        """Initialise AIS"""
+
+    @abc.abstractmethod
+    def run(self, x_base, log_prob_p0, key, transition_operator_state,
+            base_log_prob, target_log_prob) -> Tuple[X, LogWeights, TransitionOperatorState, Info]:
+        """Perform AIS"""
+
+
+    @abc.abstractmethod
+    def get_init_state(self):
+        """Returns initial state of ais transition operator."""
+

--- a/fab/sampling_methods/mcmc/base.py
+++ b/fab/sampling_methods/mcmc/base.py
@@ -1,0 +1,28 @@
+import abc
+
+from typing import Tuple
+import chex
+from fab.types import LogProbFunc
+
+
+X = chex.Array
+TransitionOperatorState = chex.ArrayTree
+AuxTransitionInfo = chex.ArrayTree
+
+class TransitionOperator(abc.ABC):
+
+    @abc.abstractmethod
+    def run(self,
+            key: chex.PRNGKey,
+            transition_operator_state: chex.ArrayTree,
+            x: chex.Array,
+            i: chex.Array,
+            transition_target_log_prob: LogProbFunc) -> \
+            Tuple[X, TransitionOperatorState, AuxTransitionInfo]:
+        """
+        Run mcmc transition towards transition_target_prob
+        """
+
+    @abc.abstractmethod
+    def get_init_state(self) -> chex.ArrayTree:
+        """Returns the initial state of the transition operator."""

--- a/fab/sampling_methods/mcmc/hamiltonean_monte_carlo.py
+++ b/fab/sampling_methods/mcmc/hamiltonean_monte_carlo.py
@@ -6,8 +6,8 @@ from functools import partial
 import chex
 from fab.types import Params
 
-from fab_vae.types import LogProbFunc
-
+from fab.types import LogProbFunc
+from fab.sampling_methods.mcmc.base import TransitionOperator
 
 
 
@@ -36,7 +36,7 @@ class Info(NamedTuple):
 
 
 
-class HamiltoneanMonteCarlo:
+class HamiltoneanMonteCarlo(TransitionOperator):
     def __init__(self, dim, n_intermediate_distributions,
                  step_tuning_method="p_accept", n_outer_steps=1, n_inner_steps=5,
                  initial_step_size: float = 0.1, lr=1e-3, max_grad=1e3):

--- a/fab/sampling_methods/mcmc/tfp_hamiltonean_monte_carlo.py
+++ b/fab/sampling_methods/mcmc/tfp_hamiltonean_monte_carlo.py
@@ -1,0 +1,82 @@
+import chex
+from typing import Tuple, NamedTuple
+
+import jax.random
+import jax
+import jax.numpy as jnp
+
+from fab.sampling_methods.mcmc.base import TransitionOperator
+from fab.types import LogProbFunc
+
+import tensorflow_probability.substrates.jax as tfp
+
+
+class HMCState(NamedTuple):
+    step_size: chex.Array
+
+
+class HamiltoneanMonteCarloTFP(TransitionOperator):
+    def __init__(self,
+                 n_intermediate_distributions: int,
+                 n_leapfrog_steps: int = 5,
+                 init_step_size: float = 1.0,
+                 tune: bool = True,
+                 target_accept_prob: float = 0.75,
+                 adaption_rate: float = 0.05,
+                 ):
+        self.n_leapfrog_steps = n_leapfrog_steps
+        self.n_intermediate_distributions = n_intermediate_distributions
+        self.init_step_size = jnp.ones(n_intermediate_distributions) * init_step_size
+        self.tune = tune
+        self.target_accept_prob = target_accept_prob
+        self.adaption_rate = adaption_rate
+
+
+    def get_init_state(self) -> chex.ArrayTree:
+        return HMCState(self.init_step_size)
+
+    def run(self,
+            key: chex.PRNGKey,
+            transition_operator_state: HMCState,
+            x: chex.Array,
+            i: chex.Array,
+            transition_target_log_prob: LogProbFunc) -> \
+            Tuple[chex.Array, chex.ArrayTree, chex.ArrayTree]:
+        step_size = transition_operator_state.step_size[i]
+        if self.tune:
+            transition_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
+                tfp.mcmc.HamiltonianMonteCarlo(
+                    transition_target_log_prob, step_size,
+                    self.n_leapfrog_steps), num_adaptation_steps=1,
+                target_accept_prob=self.target_accept_prob,
+                adaptation_rate=self.adaption_rate,
+            )
+        else:
+            transition_kernel = tfp.mcmc.HamiltonianMonteCarlo(
+                transition_target_log_prob, step_size,
+                self.n_leapfrog_steps)
+        bootstrap_results = transition_kernel.bootstrap_results(x)
+        x_new, result = transition_kernel.one_step(x, bootstrap_results, key)
+        if self.tune:
+            step_size = transition_operator_state.step_size.at[i].set(result.new_step_size)
+            transition_operator_state = HMCState(step_size=step_size)
+        return x_new, transition_operator_state, {}
+
+
+if __name__ == '__main__':
+    import time
+    key = jax.random.PRNGKey(0)
+
+    target = lambda x: jnp.mean(- x**2, axis=-1)
+    x = jnp.ones((4, 5))
+    i = jnp.array(1)
+    hmc = HamiltoneanMonteCarloTFP(n_intermediate_distributions=2, tune=True)
+    transition_operator_state = hmc.get_init_state()
+    # run = jax.jit(hmc.run, static_argnums=4)
+    run = hmc.run
+
+    for _ in range(5):
+        start_time = time.time()
+        x_new, transition_operator_state, _ = run(key, transition_operator_state, x, i, target)
+        print(time.time() - start_time)
+        print(transition_operator_state)

--- a/fab/sampling_methods/mcmc/tfp_nuts.py
+++ b/fab/sampling_methods/mcmc/tfp_nuts.py
@@ -11,20 +11,20 @@ from fab.types import LogProbFunc
 import tensorflow_probability.substrates.jax as tfp
 
 
-class HMCState(NamedTuple):
+class NUTSState(NamedTuple):
     step_size: chex.Array
 
 
-class HamiltoneanMonteCarloTFP(TransitionOperator):
+class NoUTurnSamplerTFP(TransitionOperator):
     def __init__(self,
                  n_intermediate_distributions: int,
-                 n_leapfrog_steps: int = 5,
+                 max_tree_depth: int = 10,
                  init_step_size: float = 1.0,
                  tune: bool = True,
-                 target_accept_prob: float = 0.75,
+                 target_accept_prob: float = 0.65,
                  adaption_rate: float = 0.05,
                  ):
-        self.n_leapfrog_steps = n_leapfrog_steps
+        self.max_tree_depth = max_tree_depth
         self.n_intermediate_distributions = n_intermediate_distributions
         self.init_step_size = jnp.ones(n_intermediate_distributions) * init_step_size
         self.tune = tune
@@ -32,32 +32,39 @@ class HamiltoneanMonteCarloTFP(TransitionOperator):
         self.adaption_rate = adaption_rate
 
 
-    def get_init_state(self) -> chex.ArrayTree:
-        return HMCState(self.init_step_size)
+    def get_init_state(self) -> NUTSState:
+        return NUTSState(self.init_step_size)
 
     def run(self,
             key: chex.PRNGKey,
-            transition_operator_state: HMCState,
+            transition_operator_state: NUTSState,
             x: chex.Array,
             i: chex.Array,
             transition_target_log_prob: LogProbFunc) -> \
             Tuple[chex.Array, chex.ArrayTree, chex.ArrayTree]:
+        info = {}
         step_size = transition_operator_state.step_size[i]
-        transition_kernel = tfp.mcmc.HamiltonianMonteCarlo(
-            transition_target_log_prob, step_size,
-            self.n_leapfrog_steps)
+        transition_kernel = tfp.mcmc.NoUTurnSampler(
+            target_log_prob_fn=transition_target_log_prob,
+            step_size=step_size,
+            max_tree_depth=self.max_tree_depth,
+        )
         if self.tune:
             transition_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
-                transition_kernel, num_adaptation_steps=1,
+                inner_kernel=transition_kernel,
+                num_adaptation_steps=1,
                 target_accept_prob=self.target_accept_prob,
-                adaptation_rate=self.adaption_rate,
+                adaptation_rate=self.adaption_rate
             )
+
         bootstrap_results = transition_kernel.bootstrap_results(x)
         x_new, result = transition_kernel.one_step(x, bootstrap_results, key)
         if self.tune:
             step_size = transition_operator_state.step_size.at[i].set(result.new_step_size)
-            transition_operator_state = HMCState(step_size=step_size)
-        return x_new, transition_operator_state, {}
+            transition_operator_state = NUTSState(step_size=step_size)
+            info.update({f"step_{i}": step_size[i] for
+                         i in range(self.n_intermediate_distributions)})
+        return x_new, transition_operator_state, info
 
 
 if __name__ == '__main__':
@@ -67,10 +74,10 @@ if __name__ == '__main__':
     target = lambda x: jnp.mean(- x**2, axis=-1)
     x = jnp.ones((4, 5))
     i = jnp.array(1)
-    hmc = HamiltoneanMonteCarloTFP(n_intermediate_distributions=2, tune=True)
-    transition_operator_state = hmc.get_init_state()
-    # run = jax.jit(hmc.run, static_argnums=4)
-    run = hmc.run
+    nuts = NoUTurnSamplerTFP(n_intermediate_distributions=2, tune=True)
+    transition_operator_state = nuts.get_init_state()
+    run = jax.jit(nuts.run, static_argnums=4)
+    # run = nuts.run
 
     for _ in range(5):
         start_time = time.time()

--- a/fab/sampling_methods/mcmc/tfp_nuts.py
+++ b/fab/sampling_methods/mcmc/tfp_nuts.py
@@ -50,6 +50,8 @@ class NoUTurnSamplerTFP(TransitionOperator):
             max_tree_depth=self.max_tree_depth,
         )
         if self.tune:
+            # tfp.mcmc.DualAveragingStepSizeAdaptation gives bad results,
+            # may be due to num_adaption_steps? For now just use SimpleStepSizeAdaption
             transition_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
                 inner_kernel=transition_kernel,
                 num_adaptation_steps=1,

--- a/fab/sampling_methods/mcmc/unfinished/tfp_ais.py
+++ b/fab/sampling_methods/mcmc/unfinished/tfp_ais.py
@@ -1,0 +1,64 @@
+from typing import NamedTuple
+
+import chex
+import tensorflow_probability.substrates.jax as tfp
+import jax.numpy as jnp
+
+from fab.sampling_methods.base import AnnealedImportanceSamplerBase
+
+class TransitionOperatorState(NamedTuple):
+    step_size: chex.Array
+
+
+class AnnealedImportanceSamplerTfp(AnnealedImportanceSamplerBase):
+    def __init__(self,
+                 dim: int,
+                 n_intermediate_distributions: int = 1,
+                 *args,
+                 **kwargs,
+                 ):
+        self.dim = dim
+        self.n_intermediate_distribution = n_intermediate_distributions
+        self.tune = True
+
+
+    def get_init_state(self):
+        return TransitionOperatorState(step_size=jnp.array(1.0))
+
+    def run(self, x_base, log_prob_p0, key, transition_operator_state,
+            base_log_prob, target_log_prob):
+        def make_kernel_fn(target_log_prob):
+            step_size = transition_operator_state.step_size
+            transition_kernel = tfp.mcmc.HamiltonianMonteCarlo(
+                target_log_prob_fn=target_log_prob,
+                step_size=step_size,
+                num_leapfrog_steps=2)
+            if self.tune:
+                transition_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
+                    transition_kernel, num_adaptation_steps=1,
+                    target_accept_prob=0.75,
+                    adaptation_rate=0.01,
+                )
+            return transition_kernel
+
+        x_ais, log_w_ais, kernels_results = (
+            tfp.mcmc.sample_annealed_importance_chain(
+                num_steps=self.n_intermediate_distribution,
+                proposal_log_prob_fn=base_log_prob,
+                target_log_prob_fn=target_log_prob,
+                current_state=x_base,
+                make_kernel_fn=make_kernel_fn,
+                seed=key))
+        info = {}
+        if self.tune:
+            transition_operator_state = TransitionOperatorState(
+                kernels_results.inner_results.new_step_size)
+            info.update(step_size=transition_operator_state.step_size)
+        return x_ais, log_w_ais, transition_operator_state, info
+
+
+
+
+
+
+

--- a/fab/sampling_methods/mcmc/unfinished/tfp_ais_test.py
+++ b/fab/sampling_methods/mcmc/unfinished/tfp_ais_test.py
@@ -1,0 +1,71 @@
+import jax.random
+from absl.testing import absltest
+import distrax
+from functools import partial
+from fab.target_distributions.many_well import ManyWellEnergy
+import jax.numpy as jnp
+import haiku as hk
+import chex
+
+from fab.sampling_methods.mcmc.unfinished.tfp_ais import AnnealedImportanceSamplerTfp as AnnealedImportanceSampler
+
+
+
+class Test_HMC(absltest.TestCase):
+    """See examples/visualise_ais.ipynb for further visualisation."""
+    x_ndim = 4
+    base_distribution = distrax.MultivariateNormalDiag(jnp.zeros((x_ndim,)),
+                                                         jnp.ones((x_ndim,)))
+    base_log_prob_fn = distrax.MultivariateNormalDiag(
+        jnp.zeros((x_ndim, )), jnp.ones((x_ndim,))).log_prob
+    target_log_prob = ManyWellEnergy(dim=x_ndim).log_prob
+    n_parallel_runs = 12
+    n_intermediate_distributions = 2
+    AIS = AnnealedImportanceSampler(dim=x_ndim,
+                                    n_intermediate_distributions=n_intermediate_distributions)
+    rng = hk.PRNGSequence(0)
+    x = jnp.zeros((n_parallel_runs, x_ndim))
+    init_transition_operator_state = AIS.get_init_state()
+
+
+    def test__run(self):
+        jit = True
+        x_base, log_q_base = self.base_distribution.sample_and_log_prob(seed=next(self.rng),
+                                                           sample_shape=(10,))
+        if jit:
+            run = partial(jax.jit, static_argnums=(4, 5))(self.AIS.run)
+        else:
+            run = self.AIS.run
+        x, log_w, transition_operator_state, aux_info = run(
+            x_base, log_q_base,
+            next(self.rng), self.init_transition_operator_state,
+            self.base_log_prob_fn, self.target_log_prob
+        )
+        chex.assert_equal_shape((x, x_base))
+        chex.assert_equal_shape((log_q_base, log_w))
+
+
+    def test__run_and_plot(self):
+        n_intermediate_distributions = 1000
+        batch_size = 1000
+        self.AIS = AnnealedImportanceSampler(dim=self.x_ndim,
+                                        n_intermediate_distributions=n_intermediate_distributions)
+        x_base, log_q_base = self.base_distribution.sample_and_log_prob(seed=next(self.rng),
+                                                           sample_shape=(batch_size,))
+        x, log_w, transition_operator_state, aux_info = self.AIS.run(
+            x_base, log_q_base,
+            next(self.rng), self.init_transition_operator_state,
+            self.base_log_prob_fn, self.target_log_prob
+        )
+        import matplotlib.pyplot as plt
+        plt.plot(x[:, 0], x[:, 1], "o", alpha=0.3)
+        plt.title("points from AIS")
+        plt.show()
+
+        # test that log weights thin the distribution appropriately
+        indices = jax.random.choice(jax.random.PRNGKey(0), log_w.shape[0],
+                                    p=jax.nn.softmax(log_w), shape=(1000,),
+                                    replace=True)
+        plt.plot(x[indices, 0], x[indices, 1], "o", alpha=0.3)
+        plt.title("points from AIS after resampling")
+        plt.show()

--- a/fab/sampling_methods/mcmc/unfinished/tfp_langevin_dynamics.py
+++ b/fab/sampling_methods/mcmc/unfinished/tfp_langevin_dynamics.py
@@ -11,20 +11,20 @@ from fab.types import LogProbFunc
 import tensorflow_probability.substrates.jax as tfp
 
 
-class HMCState(NamedTuple):
+class LDState(NamedTuple):
     step_size: chex.Array
 
 
-class HamiltoneanMonteCarloTFP(TransitionOperator):
+class LevanginDynamicsTFP(TransitionOperator):
     def __init__(self,
                  n_intermediate_distributions: int,
-                 n_leapfrog_steps: int = 5,
+                 max_tree_depth: int = 10,
                  init_step_size: float = 1.0,
                  tune: bool = True,
-                 target_accept_prob: float = 0.75,
+                 target_accept_prob: float = 0.65,
                  adaption_rate: float = 0.05,
                  ):
-        self.n_leapfrog_steps = n_leapfrog_steps
+        self.max_tree_depth = max_tree_depth
         self.n_intermediate_distributions = n_intermediate_distributions
         self.init_step_size = jnp.ones(n_intermediate_distributions) * init_step_size
         self.tune = tune
@@ -32,32 +32,38 @@ class HamiltoneanMonteCarloTFP(TransitionOperator):
         self.adaption_rate = adaption_rate
 
 
-    def get_init_state(self) -> chex.ArrayTree:
-        return HMCState(self.init_step_size)
+    def get_init_state(self) -> LDState:
+        return LDState(self.init_step_size)
 
     def run(self,
             key: chex.PRNGKey,
-            transition_operator_state: HMCState,
+            transition_operator_state: LDState,
             x: chex.Array,
             i: chex.Array,
             transition_target_log_prob: LogProbFunc) -> \
             Tuple[chex.Array, chex.ArrayTree, chex.ArrayTree]:
+        info = {}
         step_size = transition_operator_state.step_size[i]
-        transition_kernel = tfp.mcmc.HamiltonianMonteCarlo(
-            transition_target_log_prob, step_size,
-            self.n_leapfrog_steps)
+        transition_kernel = tfp.mcmc.MetropolisHastings(tfp.mcmc.UncalibratedLangevin(
+            target_log_prob_fn=transition_target_log_prob,
+            step_size=step_size,
+        ))
         if self.tune:
             transition_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
-                transition_kernel, num_adaptation_steps=1,
+                transition_kernel,
+                num_adaptation_steps=1,
                 target_accept_prob=self.target_accept_prob,
-                adaptation_rate=self.adaption_rate,
+                adaptation_rate=self.adaption_rate
             )
+        # there is an error here where the step size adaption is unable to grab the step size.
         bootstrap_results = transition_kernel.bootstrap_results(x)
         x_new, result = transition_kernel.one_step(x, bootstrap_results, key)
         if self.tune:
             step_size = transition_operator_state.step_size.at[i].set(result.new_step_size)
-            transition_operator_state = HMCState(step_size=step_size)
-        return x_new, transition_operator_state, {}
+            transition_operator_state = LDState(step_size=step_size)
+            info.update({f"step_{i}": step_size[i] for
+                         i in range(self.n_intermediate_distributions)})
+        return x_new, transition_operator_state, info
 
 
 if __name__ == '__main__':
@@ -67,10 +73,10 @@ if __name__ == '__main__':
     target = lambda x: jnp.mean(- x**2, axis=-1)
     x = jnp.ones((4, 5))
     i = jnp.array(1)
-    hmc = HamiltoneanMonteCarloTFP(n_intermediate_distributions=2, tune=True)
-    transition_operator_state = hmc.get_init_state()
-    # run = jax.jit(hmc.run, static_argnums=4)
-    run = hmc.run
+    nuts = LevanginDynamicsTFP(n_intermediate_distributions=2, tune=True)
+    transition_operator_state = nuts.get_init_state()
+    run = jax.jit(nuts.run, static_argnums=4)
+    # run = nuts.run
 
     for _ in range(5):
         start_time = time.time()

--- a/fab/sampling_methods/mcmc/unfinished/trans_op_blackjax.py
+++ b/fab/sampling_methods/mcmc/unfinished/trans_op_blackjax.py
@@ -1,0 +1,72 @@
+"""Doesn't allow use to grab the step size. """
+
+
+from typing import Optional, NamedTuple, Tuple
+
+import blackjax
+import blackjax.mcmc.integrators as integrators
+import jax.numpy as jnp
+import jax
+import chex
+
+from fab.sampling_methods.mcmc.base import TransitionOperator
+from fab.types import LogProbFunc
+
+
+class BlackJaxHMC(TransitionOperator):
+    def __init__(self,
+                 dim: int,
+                 init_target_log_prob: LogProbFunc,
+                 init_seed: int = 0,
+                 init_run_length: int = 1000):
+        self.init_target_log_pob = init_target_log_prob
+        self.dim = dim
+        self.num_integration_steps = 5
+        self.kernel = blackjax.hmc.kernel(integrators.mclachlan)
+        self.init_key = jax.random.PRNGKey(init_seed)
+        self.init_run_length = init_run_length
+        self.initial_position = jnp.zeros((dim,))
+
+    def get_init_state(self) -> chex.ArrayTree:
+        warmup = blackjax.window_adaptation(
+            blackjax.hmc,
+            self.init_target_log_pob,
+            self.init_run_length,
+            num_integration_steps=5
+        )
+        state, kernel, _ = warmup.run(
+            self.init_key,
+            self.initial_position,
+        )
+        self.kernel = kernel
+        return jnp.array(0)  # no transition operator state
+
+    def run(self,
+            key: chex.PRNGKey,
+            transition_operator_state: chex.ArrayTree,
+            x: chex.Array,
+            i: chex.Array,
+            transition_target_log_prob: LogProbFunc) -> \
+            Tuple[chex.Array, chex.ArrayTree, chex.ArrayTree]:
+        del(i)
+        key_batch = jax.random.split(key, x.shape[0])
+        state = jax.vmap(blackjax.hmc.init, in_axes=(0, None))(x, transition_target_log_prob)
+        state, info = jax.vmap(self.kernel, in_axes=(0, 0, None))(key_batch, state,
+                                                                  transition_target_log_prob)
+        return state, transition_operator_state, info
+
+
+
+
+
+
+if __name__ == '__main__':
+    dim = 3
+    key = jax.random.PRNGKey(0)
+    target = lambda x: jnp.mean(- x**2, axis=-1)
+    transition_oeprator = BlackJaxHMC(dim, target)
+    transition_operator_state = transition_oeprator.get_init_state()
+    x_batch = jax.random.normal(key, shape=(32, dim))
+    state, transition_operator_state, info = \
+        transition_oeprator.run(key, transition_operator_state, x_batch,
+                                jnp.array(0), target)

--- a/fab/types.py
+++ b/fab/types.py
@@ -5,7 +5,7 @@ import haiku as hk
 
 XPoints = jnp.ndarray
 LogProbs = jnp.ndarray
-TargetLogProbFunc = Callable[[XPoints], LogProbs]
+LogProbFunc = Callable[[XPoints], LogProbs]
 MCMCTransitionManager = Any
 Params = Any
 # TODO: rather define init, and then log prob like this


### PR DESCRIPTION
Decided on tfp.substrates.jax over blackjax, as blackjax doesn't easily expose internal transition operator parameters
Added:
- tfp's hmc transition kernel
- tfp's nuts transition kernel

In a simple run on the double well problem:
- hmc's appears to do better than nuts (this may just be due to parameter tuning). 
- hmc's speed looks similar to my implementation, and the step size tuning does not slow things down too much. 

tfp also have an implementation of annealed importance sampling, but on first pass this appears not to be jittable (didn't hunt for the reason why), so this was not added in the end. 